### PR TITLE
feat(rules): require dangling commas for multi-line functions

### DIFF
--- a/__tests__/__snapshots__/index.js.snap
+++ b/__tests__/__snapshots__/index.js.snap
@@ -13,7 +13,13 @@ Object {
   "rules": Object {
     "comma-dangle": Array [
       2,
-      "always-multiline",
+      Object {
+        "arrays": "always-multiline",
+        "exports": "always-multiline",
+        "functions": "always-multiline",
+        "imports": "always-multiline",
+        "objects": "always-multiline",
+      },
     ],
   },
 }

--- a/eslintrc.json
+++ b/eslintrc.json
@@ -10,6 +10,12 @@
     "browser": true
   },
   "rules": {
-    "comma-dangle": [2, "always-multiline"]
+    "comma-dangle": [2, {
+        "arrays": "always-multiline",
+        "objects": "always-multiline",
+        "imports": "always-multiline",
+        "exports": "always-multiline",
+        "functions": "always-multiline"
+    }]
   }
 }


### PR DESCRIPTION
BREAKING CHANGE:
Multi-line functions without dangling commas will now generate an error.