### PR TITLE
feat: add flowtype preset

### DIFF
--- a/__fixtures__/flowtype.js
+++ b/__fixtures__/flowtype.js
@@ -1,0 +1,13 @@
+// @flow
+
+export const CONSTANTS = {
+  FOO: 'foo',
+  BAR: 'bar',
+  BAZ: 'baz',
+}
+
+export type Constants = $Values<typeof CONSTANTS>
+
+export type Foobar = {
+  value: Constants,
+}

--- a/__snapshots__/flowtype.test.js.snap
+++ b/__snapshots__/flowtype.test.js.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`@simonkberg/eslint-config should match the snapshot 1`] = `
+Object {
+  "extends": Array [
+    "<PROJECT_ROOT>/node_modules/eslint-plugin-flowtype/dist/configs/recommended.json",
+    "<PROJECT_ROOT>/node_modules/eslint-config-prettier/flowtype.js",
+  ],
+  "parser": "<PROJECT_ROOT>/node_modules/babel-eslint/lib/index.js",
+  "plugins": Array [
+    "flowtype",
+  ],
+  "settings": Object {
+    "flowtype": Object {
+      "onlyFilesWithFlowAnnotation": true,
+    },
+  },
+}
+`;

--- a/flowtype.js
+++ b/flowtype.js
@@ -1,0 +1,15 @@
+'use strict'
+
+module.exports = {
+  parser: require.resolve('babel-eslint'),
+  plugins: ['flowtype'],
+  extends: [
+    require.resolve('eslint-plugin-flowtype/dist/configs/recommended'),
+    require.resolve('eslint-config-prettier/flowtype'),
+  ],
+  settings: {
+    flowtype: {
+      onlyFilesWithFlowAnnotation: true,
+    },
+  },
+}

--- a/flowtype.test.js
+++ b/flowtype.test.js
@@ -1,0 +1,39 @@
+/* eslint-env jest */
+
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+const config = require('./flowtype.js')
+const { CLIEngine } = require('eslint')
+
+expect.addSnapshotSerializer({
+  print: val => JSON.stringify(val.replace(__dirname, '<PROJECT_ROOT>')),
+  test: val => typeof val === 'string',
+})
+
+describe('@simonkberg/eslint-config', () => {
+  it('should match the snapshot', () => expect(config).toMatchSnapshot())
+
+  it('should load config in eslint', done => {
+    const cli = new CLIEngine({
+      ignore: false,
+      useEslintrc: false,
+      configFile: path.resolve(__dirname, 'flowtype.js'),
+    })
+
+    fs.readFile(
+      path.resolve(__dirname, '__fixtures__/flowtype.js'),
+      'utf-8',
+      (err, file) => {
+        expect(err).toBeNull()
+
+        const { errorCount, warningCount } = cli.executeOnText(file)
+
+        expect(errorCount).toBe(0)
+        expect(warningCount).toBe(0)
+        done()
+      }
+    )
+  })
+})

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "eslint-config-prettier": "^2.3.0",
     "eslint-config-standard": "^10.2.1",
     "eslint-config-standard-react": "^5.0.0",
+    "eslint-plugin-flowtype": "^2.42.0",
     "eslint-plugin-import": "^2.7.0",
     "eslint-plugin-node": "^5.1.1",
     "eslint-plugin-promise": "^3.5.0",
@@ -70,6 +71,7 @@
   },
   "files": [
     "index.js",
+    "flowtype.js",
     "react.js"
   ]
 }

--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,26 @@ yarn add --dev @simonkberg/eslint-config
 }
 ```
 
+### Flow type config
+
+#### Extends:
+
+* [eslint-plugin-flowtype/recommended][eslint-plugin-flowtype]
+* [eslint-config-prettier/flowtype][eslint-config-prettier]
+
+#### Usage:
+
+```json
+{
+  "eslintConfig": {
+    "extends": [
+      "@simonkberg/eslint-config",
+      "@simonkberg/eslint-config/flowtype"
+    ]
+  }
+}
+```
+
 ### React config
 
 #### Extends:
@@ -53,3 +73,4 @@ yarn add --dev @simonkberg/eslint-config
 [eslint-config-standard]: https://github.com/standard/eslint-config-standard
 [eslint-config-standard-react]: https://github.com/standard/eslint-config-standard-react
 [eslint-config-prettier]: https://github.com/prettier/eslint-config-prettier
+[eslint-plugin-flowtype]: https://github.com/gajus/eslint-plugin-flowtype

--- a/yarn.lock
+++ b/yarn.lock
@@ -1119,6 +1119,12 @@ eslint-module-utils@^2.1.1:
     debug "^2.6.8"
     pkg-dir "^1.0.0"
 
+eslint-plugin-flowtype@^2.42.0:
+  version "2.42.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.42.0.tgz#7fcc98df4ed9482a22ac10ba4ca48d649c4c733a"
+  dependencies:
+    lodash "^4.15.0"
+
 eslint-plugin-import@^2.7.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.8.0.tgz#fa1b6ef31fcb3c501c09859c1b86f1fc5b986894"
@@ -2624,7 +2630,7 @@ lodash.templatesettings@^4.0.0:
   dependencies:
     lodash._reinterpolate "~3.0.0"
 
-lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0:
+lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 


### PR DESCRIPTION
Using recommended rules from `eslint-plugin-flowtype`.
Only applies to files with flow annotation.

Usage:
```json
{
  "eslintConfig": {
    "extends": [
      "@simonkberg/eslint-config",
      "@simonkberg/eslint-config/flowtype"
    ]
  }
}
```