### PR TITLE
chore: drop support for node v6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ notifications:
   email: false
 node_js:
   - node
+  - lts/dubnium
   - lts/carbon
-  - lts/boron
 install: yarn --frozen-lockfile
-

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/simonkberg/eslint-config#readme",
   "engines": {
-    "node": ">= 6"
+    "node": ">= 8"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
BREAKING CHANGE: Minimum supported node version is v8