### PR TITLE
chore: drop support for node 8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['8', '10', '12']
+        node-version: ['10', '12']
     steps:
       - uses: actions/checkout@v1
       - name: Node.js ${{ matrix.node-version }}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/simonkberg/eslint-config#readme",
   "engines": {
-    "node": ">= 8"
+    "node": ">= 10"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
BREAKING CHANGE: requires node v10+